### PR TITLE
Updated default duply version to 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Set up [duply](http://duply.net/), a shell front-end for the mighty [duplicity](
 
 #### Variables
 
-* `duply_version`: [default: `1.11.2`]: Duply [version](https://github.com/Oefenweb/duply/releases) to install
+* `duply_version`: [default: `2.0.1`]: Duply [version](https://github.com/Oefenweb/duply/releases) to install
 * `duply_install`: [default: `[]`]: Additional packages to install (e.g. `duplicity`)
 * `duply_install_dir` [default: `/usr/local/bin`]: Install directory
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 # defaults file for duply
 ---
-duply_version: '1.11.2'
+duply_version: '2.0.1'
 duply_install: []
 duply_install_dir: /usr/local/bin


### PR DESCRIPTION
Changing the default version to 2.0.1 to go along with Oefenweb/duply#1